### PR TITLE
use suprematism-scss colors, fix too low z-index

### DIFF
--- a/out-tsc/card-navbar/card-navbar.component.css
+++ b/out-tsc/card-navbar/card-navbar.component.css
@@ -1,7 +1,8 @@
 .CardNavbar {
   display: block;
   font-family: Verdana;
-  width: 100%; }
+  width: 100%;
+  z-index: 200000; }
 
 .CardNavbar-navbar {
   display: flex;
@@ -21,8 +22,8 @@
   left: 0px;
   width: 75px;
   height: 60px;
-  z-index: 999; }
+  z-index: 800000; }
 
 .CardNavbar-cards {
   position: relative;
-  z-index: 100000; }
+  z-index: 200000; }

--- a/out-tsc/card-navbar/card-navbar.component.css
+++ b/out-tsc/card-navbar/card-navbar.component.css
@@ -25,4 +25,4 @@
 
 .CardNavbar-cards {
   position: relative;
-  z-index: 888; }
+  z-index: 100000; }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
   },
   "dependencies": {
     "suprematism-dropdown-image": "github:cinbcuniversal/suprematism-dropdown-image",
-    "suprematism-scss": "github:cinbcuniversal/suprematism-scss"
+    "suprematism-scss": "github:cinbcuniversal/suprematism-scss#z-indexes"
   }
 }

--- a/src/card-navbar/card-navbar.component.css
+++ b/src/card-navbar/card-navbar.component.css
@@ -1,7 +1,8 @@
 .CardNavbar {
   display: block;
   font-family: Verdana;
-  width: 100%; }
+  width: 100%;
+  z-index: 200000; }
 
 .CardNavbar-navbar {
   display: flex;
@@ -21,8 +22,8 @@
   left: 0px;
   width: 75px;
   height: 60px;
-  z-index: 999; }
+  z-index: 800000; }
 
 .CardNavbar-cards {
   position: relative;
-  z-index: 100000; }
+  z-index: 200000; }

--- a/src/card-navbar/card-navbar.component.css
+++ b/src/card-navbar/card-navbar.component.css
@@ -25,4 +25,4 @@
 
 .CardNavbar-cards {
   position: relative;
-  z-index: 888; }
+  z-index: 100000; }

--- a/src/card-navbar/card-navbar.component.scss
+++ b/src/card-navbar/card-navbar.component.scss
@@ -5,6 +5,7 @@
   display: block;
   font-family: Verdana;
   width: 100%;
+  z-index: $z-index-navbar;
 }
 .CardNavbar-navbar {
   display: flex;
@@ -24,9 +25,9 @@
   left: 0px;
   width: 75px;
   height: 60px;
-  z-index: 999;
+  z-index: $z-index-popover;
 }
 .CardNavbar-cards {
   position: relative;
-  z-index: $z-index-dropdown-backdrop;
+  z-index: $z-index-navbar;
 }

--- a/src/card-navbar/card-navbar.component.scss
+++ b/src/card-navbar/card-navbar.component.scss
@@ -1,6 +1,5 @@
-$blue: rgba(0, 137, 208, 1);
-$blue-transparent: rgba(0, 137, 208, .3);
-$gray: #999999;
+@import '../../node_modules/suprematism-scss/z-indexes';
+@import '../../node_modules/suprematism-scss/colors';
 
 .CardNavbar {
   display: block;
@@ -29,5 +28,5 @@ $gray: #999999;
 }
 .CardNavbar-cards {
   position: relative;
-  z-index: 888;
+  z-index: $z-index-dropdown-backdrop;
 }

--- a/src/card-navbar/cards/card/card.component.scss
+++ b/src/card-navbar/cards/card/card.component.scss
@@ -1,6 +1,4 @@
-$blue: rgba(0, 137, 208, 1);
-$blue-transparent: rgba(0, 137, 208, .3);
-$gray: #999999;
+@import '../../../../node_modules/suprematism-scss/colors';
 
 a {
   color: inherit;
@@ -15,7 +13,7 @@ a {
   margin-bottom: 30px;
   height: 100px;
   width: 100px;
-  border: 2px dotted $gray;
+  border: 2px dotted $gray-light-warm;
   border-radius: 12px;
   cursor: pointer;
 }
@@ -24,7 +22,7 @@ a {
 }
 .CardNavbar-card.is-preSelected {
   border: 2px solid $blue;
-  background-color: $blue-transparent;
+  background-color: $blue-transparent-light;
 }
 .CardNavbar-card.is-selected {
   border: 2px solid $blue;
@@ -36,7 +34,7 @@ a {
   margin-bottom: 12px;
   text-align: center;
   text-transform: uppercase;
-  color: $gray;
+  color: $gray-light-warm;
   font-weight: 600;
   display: block;
   line-height: 1em;
@@ -44,7 +42,7 @@ a {
 .CardNavbar-cardIcon {
   font-size: 40px;
   text-align: center;
-  color: $gray;
+  color: $gray-light-warm;
   line-height: 1em;
 }
 .CardNavbar-cardTitle,

--- a/src/card-navbar/cards/cards.component.scss
+++ b/src/card-navbar/cards/cards.component.scss
@@ -1,6 +1,4 @@
-$blue: rgba(0, 137, 208, 1);
-$blue-transparent: rgba(0, 137, 208, .3);
-$gray: #999999;
+@import '../../../node_modules/suprematism-scss/colors';
 
 :host[suprefortab="user"] {
   width: 300px;

--- a/src/card-navbar/cards/custom-card/custom-card.component.scss
+++ b/src/card-navbar/cards/custom-card/custom-card.component.scss
@@ -1,7 +1,3 @@
-$blue: rgba(0, 137, 208, 1);
-$blue-transparent: rgba(0, 137, 208, .3);
-$gray: #999999;
-
 a {
   color: inherit;
   text-decoration: none;

--- a/src/card-navbar/menu-item/menu-item.component.scss
+++ b/src/card-navbar/menu-item/menu-item.component.scss
@@ -1,6 +1,5 @@
-$blue: rgba(0, 137, 208, 1);
-$blue-transparent: rgba(0, 137, 208, .3);
-$gray: #999999;
+@import '../../../node_modules/suprematism-scss/colors';
+
 $white-transparent: rgba(255, 255, 255, .75);
 
 a {


### PR DESCRIPTION
@akersinformz resolves z-index issue of card-navbar's cards being beneath the data-grid by using z-indexes defined in suprematism-scss. while i was in the scss, i swapped out raw color variable definitions with variables from suprematism-scss.