### PR TITLE
add functionality for stub card / hover-only menu item

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The top level menu items of the card navbar.
 
 ##### Directives
 - `supreTabId:string` - A string uniquely identifying the menu item.
-- `supreRouterLink:string` - A string identifying the routerLink for the menu item.
+- `supreRouterLink?:string` - A string identifying the routerLink for the menu item, or leave empty if no a route.
 
 ##### States
 - [default]

--- a/example/app/main.component.html
+++ b/example/app/main.component.html
@@ -41,13 +41,13 @@
       <supre-card-navbar-card-icon><div class="icon ion-record"></div></supre-card-navbar-card-icon>
     </supre-card-navbar-card>
   </supre-card-navbar-cards>
-  <supre-card-navbar-menu-item supreTabId="user" supreRouterLink="user/settings">Mary Popins</supre-card-navbar-menu-item>
+  <supre-card-navbar-menu-item supreTabId="user">Mary Popins</supre-card-navbar-menu-item>
   <supre-card-navbar-cards supreForTab="user">
-    <supre-card-navbar-card supreForTab="user" supreCardId="logout" supreRouterLink>
+    <supre-card-navbar-card supreForTab="user" supreCardId="logout">
       <supre-card-navbar-card-title>Log Out</supre-card-navbar-card-title>
       <supre-card-navbar-card-icon><div class="icon ion-log-out"></div></supre-card-navbar-card-icon>
     </supre-card-navbar-card>
-    <supre-card-navbar-card supreForTab="user" supreCardId="settings" supreRouterLink [supreDefaultCardForTab]="true">
+    <supre-card-navbar-card supreForTab="user" supreCardId="settings" supreRouterLink>
       <supre-card-navbar-card-title>Settings</supre-card-navbar-card-title>
       <supre-card-navbar-card-icon><div class="icon ion-ios-gear"></div></supre-card-navbar-card-icon>
     </supre-card-navbar-card>

--- a/src/card-navbar/cards/card/card.component.html
+++ b/src/card-navbar/cards/card/card.component.html
@@ -1,10 +1,10 @@
-<a [routerLink]="routerLink">
+<a (click)="onClick($event)" [routerLink]="routerLink">
   <div class="CardNavbar-card"
-      (mousedown)="rawStateSource.next('preSelected')"
-      (mouseup)="rawStateSource.next('selected')"
-      (mouseenter)="rawStateSource.next('active')"
-      (mouseout)="rawStateSource.next('notActive')"
-      [ngClass]="['is-' + (state$ | async)]"
+    (mousedown)="routerLink && rawStateSource.next('preSelected')"
+    (mouseup)="routerLink && rawStateSource.next('selected')"
+    (mouseenter)="routerLink && rawStateSource.next('active')"
+    (mouseout)="routerLink && rawStateSource.next('notActive')"
+    [ngClass]="[routerLink ? 'is-' + (state$ | async) : 'is-disabled']"
   >
     <div class="CardNavbar-cardTitle"><ng-content select="supre-card-navbar-card-title"></ng-content></div>
     <div class="CardNavbar-cardIcon"><ng-content select="supre-card-navbar-card-icon"></ng-content></div>

--- a/src/card-navbar/cards/card/card.component.scss
+++ b/src/card-navbar/cards/card/card.component.scss
@@ -19,6 +19,9 @@ a {
   border-radius: 12px;
   cursor: pointer;
 }
+.CardNavbar-card.is-disabled {
+  cursor: default;
+}
 .CardNavbar-card.is-active {
   border: 2px solid $purple;
 }

--- a/src/card-navbar/cards/card/card.component.ts
+++ b/src/card-navbar/cards/card/card.component.ts
@@ -18,7 +18,7 @@ export class CardNavbarCardComponent implements OnInit {
 
   @Input() supreCardId: string;
 
-  @Input() supreDefaultCardForTab: boolean = false;
+  @Input() supreDefaultCardForTab = false;
 
   routerLink: string;
   @Input()
@@ -90,6 +90,13 @@ export class CardNavbarCardComponent implements OnInit {
     this.state$ = this.localState$.merge(notActive$, selected$)
       .combineLatest(isSelectedCard$)
       .map(([state, selected]) => selected ? 'selected' : state);
+  }
+
+  onClick(event) {
+    if (!this.routerLink) {
+      event.preventDefault();
+      return;
+    }
   }
 
 }

--- a/src/card-navbar/menu-item/menu-item.component.html
+++ b/src/card-navbar/menu-item/menu-item.component.html
@@ -1,7 +1,7 @@
-<a [routerLink]="supreRouterLink" class="CardNavbar-topMenuItemContainer">
+<a (click)="onClick($event)" [routerLink]="routerLink" class="CardNavbar-topMenuItemContainer">
   <div
-    (mousedown)="rawStateSource.next('preSelected')"
-    (mouseup)="rawStateSource.next('selected')"
+    (mousedown)="routerLink && rawStateSource.next('preSelected')"
+    (mouseup)="routerLink && rawStateSource.next('selected')"
     (mouseenter)="rawStateSource.next('active')"
     (mouseleave)="!isInCards($event) && rawStateSource.next('notActive')"
     class="CardNavbar-topMenuItem"

--- a/src/card-navbar/menu-item/menu-item.component.ts
+++ b/src/card-navbar/menu-item/menu-item.component.ts
@@ -42,7 +42,15 @@ export class CardNavbarMenuItemComponent implements OnInit {
 
   @Input() supreTabId: string;
 
-  @Input() supreRouterLink: string;
+  routerLink: string;
+  @Input()
+  set supreRouterLink(routerLink) {
+    if (routerLink) {
+      this.routerLink = routerLink;
+    } else {
+      this.routerLink = void 0;
+    }
+  }
 
 
   // ------ Constructor ------------------------------------------------------
@@ -90,6 +98,13 @@ export class CardNavbarMenuItemComponent implements OnInit {
     // Todo: using document.querySelector doesn't seem like the angular way
     const el = $event.toElement || $event.relatedTarget;
     return document.querySelector('.js-cards').contains(el);
+  }
+
+  onClick(event) {
+    if (!this.routerLink) {
+      event.preventDefault();
+      return;
+    }
   }
 
 }


### PR DESCRIPTION
If a `supreRouterLink` is not supplied to a card / menu-item, the element no longer acts like a navigation to a route. 

In the case of a card, this is useful for a disabled route.
In the case of a menu-item, this is useful for an item which is used to display the cards, but which is not a link itself (eg, a user profile menu item that displays options, but is itself not a link).

@CINBCUniversal/suprematism 